### PR TITLE
Don't insert new lines after javadoc @param

### DIFF
--- a/src/main/resources/spotless/eclipse-config.xml
+++ b/src/main/resources/spotless/eclipse-config.xml
@@ -8,7 +8,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
 		<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="false"/>
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-		<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+		<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
 		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>


### PR DESCRIPTION
spotless was previously configured to always wrap after @param tags.