### PR TITLE
Set up travis caches per travis docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 # https://docs.travis-ci.com/user/customizing-the-build/
 
 # Speed up build with travis caches
+# https://docs.travis-ci.com/user/languages/java/#Caching
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
     - $HOME/.gradle/caches/


### PR DESCRIPTION
```
 # Speed up build with travis caches
 # https://docs.travis-ci.com/user/languages/java/#Caching
before_cache:
  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
    - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
    cache:
      directories:
          - $HOME/.gradle/caches/
              - $HOME/.gradle/wrapper/
```